### PR TITLE
fix: resolve npm publish failures (EOTP and provenance 422 errors)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "author": "TheScriptingGuy",
   "description": "A Joplin plugin to create repeating to-dos (version 2)",
   "version": "1.1.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TheScriptingGuy/Joplin-Repeating-Todos-Plugin"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

- Add `--ignore-scripts` to `npm ci` in the publish workflow to skip the redundant `prepare`/dist build during install (dist is built explicitly in a later step)
- Clarify in workflow comments that `NPM_TOKEN` must be a **Granular Access Token** with read/write permissions — classic Automation tokens no longer exist in npm (2026), and using a Publish token causes `npm error code EOTP`
- Add `repository.url` to `package.json` — npm provenance (sigstore) validates the package origin against the GitHub Actions OIDC claims; without this field publish fails with `422 Unprocessable Entity: failed to validate repo information`

## Test plan

- [ ] Create a Granular Access Token on npmjs.com (profile → Access Tokens → Generate New Token → Granular Access Token, with Read and write permission on packages)
- [ ] Update the `NPM_TOKEN` repository secret with the new token
- [ ] Trigger the publish workflow (via a release or `workflow_dispatch`) and confirm it completes without EOTP or 422 errors

https://claude.ai/code/session_01TUoNUTkkrMsQ8WjhHeh1AL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUoNUTkkrMsQ8WjhHeh1AL)_