### PR TITLE
feat: reset the alarm of a repeating to-do that was never marked done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Reset the alarm of a repeating to-do that was never marked done: when an occurrence passes, the alarm is re-armed on the next one, the to-do stays open and its sub-tasks keep their progress. Controlled by the new "Reset the alarm even when the to-do is not done" setting, which is on by default — turn it off for the previous completion-only behaviour
 - Store recurrence settings in Joplin note userData (synchronised, invisible) instead of YAML frontmatter in the note body; one-time automatic migration of existing frontmatter
 - Drive recurrence from Joplin's to-do alarm: advance the alarm/due date on completion via note-change and alarm-trigger events, with a periodic sweep as a safety net
 - Fix `getNextDateAfter` (it never returned a value) and overdue-todo handling

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A powerful and comprehensive plugin for to-do repetition/recurrence in [Joplin](
 
 ## Overview
 
-When a recurring to-do is marked complete, this plugin immediately resets the alarm date to the next recurrence and unmarks it as completed — so your to-do list is always up to date without any manual work.
+When a recurring to-do is marked complete, this plugin immediately resets the alarm date to the next recurrence and unmarks it as completed — so your to-do list is always up to date without any manual work. To-dos you *don't* get around to are not left behind either: by default a passed alarm is simply re-armed on the next occurrence, and you can [switch that off](#plugin-settings) if you would rather they stay overdue.
 
 Supported recurrence intervals: **minute, hour, day, week, month, year**
 
@@ -107,7 +107,7 @@ When **months** is selected, you can specify a particular weekday of the month (
 
 #### Step 7 — Save
 
-Click **OK** to save. The recurrence is now active. The next time you mark the to-do complete it will automatically reschedule.
+Click **OK** to save. The recurrence is now active. It reschedules automatically the next time you mark the to-do complete — or, unless you turn that off in the [plugin settings](#plugin-settings), the next time its alarm passes without it being done.
 
 ---
 
@@ -121,6 +121,11 @@ Access these options from **Tools → Repeating To-dos**:
 | **Update Overdue To-Dos** | Marks overdue to-dos complete and rolls their due date forward to the next occurrence past today |
 | **Reschedule Overdue To-Dos to Today** | Keeps the to-dos open but moves their due date to today (preserving the original time-of-day) |
 
+> With **Reset the alarm even when the to-do is not done** on (the default), overdue repeating
+> to-dos are already moved on automatically, so these commands are mostly a manual nudge. Note that
+> *Reschedule Overdue To-Dos to Today* can land on a time that has already passed today, in which
+> case the next automatic reset moves it on again.
+
 ### Plugin Settings
 
 Go to **Tools → Options → Repeating To-dos** to configure:
@@ -128,13 +133,41 @@ Go to **Tools → Options → Repeating To-dos** to configure:
 | Setting | Default | Description |
 |---|---|---|
 | Update frequency (seconds) | 30 | How often the safety-net sweep checks for missed recurring to-dos |
+| Reset the alarm even when the to-do is not done | **On** | Re-arms the alarm on the next occurrence when one passes without the to-do being completed. Turn it off to only advance to-dos when they are ticked off (the previous behaviour) |
 | Enable debug logging | Off | Writes detailed trace output to the developer console |
+
+#### Resetting the alarm without completing the to-do
+
+By default, a repeating to-do no longer waits to be ticked off before it moves on. When its alarm
+passes while the to-do is still open, the plugin skips that occurrence and re-arms the alarm on the
+next one — so a "water the plants every day" reminder pops up again tomorrow instead of sitting
+overdue forever.
+
+On the reset path the plugin deliberately does **less** than it does on completion:
+
+| | Completed | Alarm reset (not done) |
+|---|---|---|
+| Due date / alarm moves to the next occurrence | ✅ | ✅ |
+| To-do is re-opened | ✅ | — (it was never closed) |
+| Sub-tasks are reset to unchecked | ✅ | — (your progress is kept) |
+| Counts against an "after N times" stop condition | ✅ | ✅ |
+
+If several occurrences were missed — Joplin was closed over the weekend, say — the to-do is skipped
+forward far enough that the new alarm always lands in the future. Missed alarms are caught by the
+alarm event when Joplin is running, and by the safety-net sweep on startup when it was not.
+
+Turn the setting off in **Tools → Options → Repeating To-dos** to get the old behaviour, where an
+overdue to-do stays overdue until you complete it.
 
 ---
 
 ## How It Works
 
 ### Scheduling Flow
+
+Two things move a recurring to-do on to its next occurrence: completing it, or — with **Reset the
+alarm even when the to-do is not done** enabled (the default) — its alarm passing while it is still
+open.
 
 When you mark a recurring to-do as complete, the plugin immediately:
 
@@ -145,20 +178,29 @@ When you mark a recurring to-do as complete, the plugin immediately:
 5. Resets any sub-tasks to incomplete
 6. Checks whether the stop condition has been reached
 
+When an alarm passes on a to-do you have not done, steps 4 and 5 are skipped: the to-do stays open
+and keeps its sub-task progress, and only the alarm is moved forward.
+
 ```mermaid
 flowchart TD
-    A([User marks to-do complete]) --> B{Is it a\nrecurring to-do?}
-    B -- No --> C([Stays completed])
+    A([To-do completed\nor alarm fired]) --> B{Is it a\nrecurring to-do?}
+    B -- No --> C([Nothing to do])
     B -- Yes --> D{Has a\ndue date set?}
     D -- No --> C
-    D -- Yes --> E[Calculate next\noccurrence date]
+    D -- Yes --> Q{Marked\ncomplete?}
+    Q -- No --> R{Alarm passed and\nalarm reset enabled?}
+    R -- No --> S([Leave it alone\nwaits for completion])
+    R -- Yes --> T[Calculate first occurrence\nstrictly in the future]
+    T --> F
+    Q -- Yes --> E[Calculate next\noccurrence date]
     E --> F[Set due date\nto next occurrence]
-    F --> G[Mark to-do\nas incomplete]
-    G --> H[Reset sub-tasks\nto incomplete]
-    H --> I[Check stop condition]
+    F --> G{Was it\ncompleted?}
+    G -- No --> I[Check stop condition]
+    G -- Yes --> H[Mark to-do incomplete\nand reset sub-tasks]
+    H --> I
     I --> J{Stop condition\nreached?}
-    J -- Yes --> K([Remove from recurring index\nstays complete permanently])
-    J -- No --> L([Save updated settings\nwaits for next completion])
+    J -- Yes --> K([Remove from recurring index\nstops repeating])
+    J -- No --> L([Save updated settings\nwaits for next occurrence])
 ```
 
 ---
@@ -232,22 +274,21 @@ flowchart TD
 
     B --> F{Note changed}
     F --> G[Debounce 500 ms\nper note]
-    G --> H[Process to-do\nif now complete]
+    G --> H[Process to-do]
 
     C --> I{Alarm fired}
-    I --> J{Is the to-do\nalready complete?}
-    J -- Yes --> H
-    J -- No --> K([No-op:\nalarm just notified the user])
+    I --> H
 
     E --> L[Sweep all recurring\nto-dos in index]
     L --> H
 
     H --> M{Recurrence\nconditions met?}
-    M -- Yes --> N([Advance due date\nunmark complete])
-    M -- No --> O([Skip])
+    M -- Completed --> N([Advance due date\nunmark complete\nreset sub-tasks])
+    M -- Alarm passed,\nnot done --> P([Advance due date only\nto-do stays open])
+    M -- Neither --> O([Skip])
 
     style N fill:#d4edda
-    style K fill:#fff3cd
+    style P fill:#d4edda
     style O fill:#fff3cd
 ```
 
@@ -338,14 +379,14 @@ Enable **debug logging** in **Tools → Options → Repeating To-dos** to see de
 | Class | Responsibility |
 |---|---|
 | `RecurrenceStore` | Reads/writes recurrence settings to Joplin's `userData` API per note; maintains the `recurring` index tag |
-| `RecurrenceManager` | Core logic: processes a completed to-do, computes the next date, advances the alarm, handles overdue scenarios |
+| `RecurrenceManager` | Core logic: processes a completed to-do (or a passed alarm on an open one), computes the next date, advances the alarm, handles overdue scenarios |
 | `RecurrenceScheduler` | Wires up `onNoteChange` and `onNoteAlarmTrigger` Joplin events; runs a periodic safety-net sweep |
 | `SettingsManager` | Registers the plugin settings section and restarts the scheduler when settings change |
 | `CommandManager` | Registers the four Joplin commands exposed in the toolbar and menu |
 | `Recurrence` (model) | Holds all recurrence fields; implements `getNextDate`, `getNextDateAfter`, `updateStopStatus` |
 
 **Key design decisions:**
-- Advancement is **event-driven** (note change / alarm), not purely polling — this means the to-do advances the moment it is checked off, not at the next sweep interval
+- Advancement is **event-driven** (note change / alarm), not purely polling — this means the to-do advances the moment it is checked off, or the moment its alarm fires, not at the next sweep interval
 - The safety-net sweep (default every 30 s) catches anything the event listeners may have missed (e.g. a completion that happened while Joplin was closed)
 - Recurrence data is stored in `userData` (not in the note body) so it survives note edits and syncs cleanly across devices
 - Legacy YAML frontmatter from older plugin versions is automatically migrated to `userData` on first access

--- a/e2e/recurrence-advance.spec.ts
+++ b/e2e/recurrence-advance.spec.ts
@@ -10,6 +10,22 @@ import {
   isTodoComplete,
 } from './helpers';
 
+/** Format a Date as the 'YYYY-MM-DDTHH:MM' local string Joplin's alarm input uses. */
+function alarmString(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
+    d.getHours()
+  )}:${pad(d.getMinutes())}`;
+}
+
+/** A date `days` days from now at 09:00 local time. */
+function daysFromNow(days: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  d.setHours(9, 0, 0, 0);
+  return d;
+}
+
 /**
  * Headline behavior: when a recurring to-do (with an alarm) is marked complete, the plugin
  * asynchronously (via onNoteChange) advances its alarm by the configured interval and re-marks
@@ -31,8 +47,10 @@ test.describe('Recurrence advancement', () => {
     const { win } = joplin;
     await createTodo(win, 'Advance Todo ' + Date.now());
 
-    const ORIGINAL = '2026-06-01T09:00';
-    const EXPECTED = '2026-06-02T09:00';
+    // Deliberately in the future: an alarm that has already passed would be rolled forward by the
+    // "reset alarm when not done" behaviour before we get to complete it (see the next test).
+    const ORIGINAL = alarmString(daysFromNow(30));
+    const EXPECTED = alarmString(daysFromNow(31));
 
     // Give it an alarm (required for advancement), then make it repeat daily.
     await setAlarm(win, ORIGINAL);
@@ -55,29 +73,32 @@ test.describe('Recurrence advancement', () => {
       .toBe(EXPECTED);
   });
 
-  test('completing an OVERDUE (past-alarm) recurring to-do advances by one interval, not to today', async () => {
+  test('an OVERDUE (past-alarm) recurring to-do has its alarm reset forward without being completed', async () => {
     const { win } = joplin;
     await createTodo(win, 'Overdue Todo ' + Date.now());
 
-    // Alarm well in the past — the "overdue" path.
+    // Alarm well in the past — the missed-occurrence path. With the default
+    // `resetAlarmWhenNotDone` setting the plugin re-arms the alarm on the next occurrence without
+    // the to-do ever being ticked off. The alarm event already fired long ago, so what picks this
+    // up is the periodic safety-net sweep (default every 30 s).
     const ORIGINAL = '2020-03-10T08:00';
-    const EXPECTED = '2020-03-11T08:00';
 
     await setAlarm(win, ORIGINAL);
     await setRecurrence(win, { enabled: true, interval: 'day' });
-    expect(await readAlarm(win)).toBe(ORIGINAL);
 
-    await completeTodo(win);
-
-    // Plugin re-opens the to-do (completion-driven advancement runs regardless of past/future).
     await expect
-      .poll(async () => isTodoComplete(win), { timeout: 15_000, intervals: [500] })
-      .toBe(false);
+      .poll(async () => readAlarm(win), { timeout: 90_000, intervals: [2000] })
+      .not.toBe(ORIGINAL);
 
-    // The alarm advances by exactly one interval from the stored due date — it is NOT rescheduled
-    // to "today" (that only happens via the manual "Reschedule overdue to-dos" command).
-    await expect
-      .poll(async () => readAlarm(win), { timeout: 15_000, intervals: [1000] })
-      .toBe(EXPECTED);
+    const advanced = await readAlarm(win);
+    // Same time of day, but the occurrence it landed on is in the future — every missed daily
+    // occurrence between 2020 and now was skipped in one go.
+    expect(advanced.endsWith('T08:00'), `alarm kept its time of day: ${advanced}`).toBe(true);
+    expect(new Date(advanced).getTime(), `alarm moved into the future: ${advanced}`).toBeGreaterThan(
+      Date.now()
+    );
+
+    // KEY ASSERTION: the to-do was never marked complete along the way — only the alarm moved.
+    expect(await isTodoComplete(win)).toBe(false);
   });
 });

--- a/src/core/recurrence.ts
+++ b/src/core/recurrence.ts
@@ -9,9 +9,10 @@ import { Trace, TryCatch } from './decorators';
 /**
  * Central manager for all recurrence-related logic.
  *
- * The engine is alarm/event-native: advancement happens when a recurring to-do is marked complete
- * (observed via note-change / alarm events), not by polling note state. `updateAllRecurrences` remains
- * as a periodic safety-net sweep in case an event was missed.
+ * The engine is alarm/event-native: advancement happens when a recurring to-do is marked complete,
+ * or when its alarm passes while it is still open (observed via note-change / alarm events), not by
+ * polling note state. `updateAllRecurrences` remains as a periodic safety-net sweep in case an event
+ * was missed — which is also what catches alarms that elapsed while Joplin was closed.
  *
  * Persistence convention used throughout: when `recurrence.enabled` is true we `RecurrenceStore.set`,
  * and when it is false (e.g. after `updateStopStatus` exhausts a count/date limit, or the dialog
@@ -133,22 +134,28 @@ export class RecurrenceManager {
   }
 
   /**
-   * Event hook: an alarm fired for a note. Advancement happens on completion, so if the to-do is
-   * already complete we advance (same path as a note-change); otherwise the alarm merely notified
-   * the user and we no-op.
+   * Event hook: an alarm fired for a note. A completed to-do advances exactly as it would on a
+   * note-change; an open one is rolled on to its next occurrence when the `resetAlarmWhenNotDone`
+   * setting is on (the default), which re-arms the alarm without the to-do ever being ticked off.
+   * Both cases are handled by `processTodo`, so the alarm is just another way in.
    */
   @Trace()
   @TryCatch({ logError: true })
   static async handleAlarm(noteId: string): Promise<void> {
-    const note = await JoplinAPI.getNote(noteId);
-    if (!note) return;
-
-    if (note.todo_completed && note.todo_completed !== 0) {
-      await this.handleNoteChange(noteId);
-    }
+    await this.handleNoteChange(noteId);
   }
 
-  /** Core recurrence engine. */
+  /**
+   * Core recurrence engine.
+   *
+   * Two paths advance a to-do to its next occurrence:
+   *  - completion — the to-do was ticked off. It is reopened and its sub-tasks are reset.
+   *  - alarm reset — the due date/alarm passed while the to-do was still open, and
+   *    `resetAlarmWhenNotDone` is enabled. The missed occurrence is skipped and the alarm re-armed
+   *    on the next one; the to-do stays open and any sub-task progress is left untouched.
+   *
+   * Both paths consume one occurrence, so a stop-after-N recurrence counts skipped alarms too.
+   */
   @Trace()
   @TryCatch({ logError: true })
   private static async processTodo(
@@ -157,31 +164,56 @@ export class RecurrenceManager {
   ): Promise<void> {
     const recurrence = todo.recurrence;
 
-    if (
-      todo.todo_completed !== 0 &&
-      todo.todo_due !== 0 &&
-      recurrence.enabled
-    ) {
-      const initialDate = new Date(todo.todo_due);
-      const nextDate =
-        after == null
-          ? recurrence.getNextDate(initialDate)
-          : recurrence.getNextDateAfter(initialDate, after);
+    if (todo.todo_due === 0 || !recurrence.enabled) return;
 
-      if (!nextDate) return;
+    const completed = todo.todo_completed !== 0;
+    const now = new Date();
 
-      await JoplinAPI.setTaskDueDate(todo.id, nextDate);
+    if (!completed) {
+      // An open to-do only moves on once its alarm has actually passed, and only if the user has
+      // left the alarm-reset setting on.
+      if (todo.todo_due > now.getTime()) return;
+      if (!(await this.resetAlarmWhenNotDone())) return;
+    }
+
+    const initialDate = new Date(todo.todo_due);
+    // A skipped occurrence has to land in the future, otherwise a to-do that was missed several
+    // intervals ago (Joplin closed over the weekend, say) would only creep forward one step.
+    const notBefore = after ?? (completed ? null : now);
+    const nextDate =
+      notBefore == null
+        ? recurrence.getNextDate(initialDate)
+        : recurrence.getNextDateAfter(initialDate, notBefore);
+
+    if (!nextDate) return;
+
+    await JoplinAPI.setTaskDueDate(todo.id, nextDate);
+
+    if (completed) {
       await JoplinAPI.markTaskIncomplete(todo.id);
       await JoplinAPI.markSubTasksIncomplete(todo.id);
+    }
 
-      recurrence.updateStopStatus();
+    recurrence.updateStopStatus();
 
-      if (recurrence.enabled) {
-        await RecurrenceStore.set(todo.id, recurrence);
-      } else {
-        // The recurrence just hit its stop condition; drop it from the index.
-        await RecurrenceStore.remove(todo.id);
-      }
+    if (recurrence.enabled) {
+      await RecurrenceStore.set(todo.id, recurrence);
+    } else {
+      // The recurrence just hit its stop condition; drop it from the index.
+      await RecurrenceStore.remove(todo.id);
+    }
+  }
+
+  /**
+   * Reads the `resetAlarmWhenNotDone` setting. Defaults to true so an unreadable or not-yet-
+   * registered value keeps the documented default behaviour.
+   */
+  private static async resetAlarmWhenNotDone(): Promise<boolean> {
+    try {
+      const value = await joplin.settings.value('resetAlarmWhenNotDone');
+      return value === undefined || value === null ? true : Boolean(value);
+    } catch {
+      return true;
     }
   }
 }

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -32,6 +32,18 @@ export class SettingsManager {
         minimum: 10,
         maximum: 3600,
       },
+      resetAlarmWhenNotDone: {
+        label: 'Reset the alarm even when the to-do is not done',
+        description:
+          'When a repeating to-do\'s alarm passes without it being marked as done, re-arm the ' +
+          'alarm on the next occurrence anyway. The to-do stays open and its sub-tasks keep ' +
+          'their progress. Turn this off to only advance repeating to-dos when they are ' +
+          'completed (the previous behaviour).',
+        value: true,
+        type: SettingItemType.Bool,
+        public: true,
+        section: this.SECTION_ID,
+      },
       debug: {
         label: 'Enable debug logging',
         description: 'Logs detailed info to the developer console',

--- a/test/recurrence.manager.test.ts
+++ b/test/recurrence.manager.test.ts
@@ -3,6 +3,7 @@
 // The storage layer (RecurrenceStore) and the Joplin wrapper (JoplinAPI) are mocked so the engine
 // logic can be asserted in isolation. The real Recurrence model is used so date math is exercised.
 
+import joplin from 'api';
 import { RecurrenceManager } from '../src/core/recurrence';
 import { RecurrenceStore, RecurringTodo } from '../src/core/database';
 import { JoplinAPI } from '../src/core/joplin';
@@ -13,6 +14,23 @@ jest.mock('../src/core/joplin');
 
 const mockStore = RecurrenceStore as jest.Mocked<typeof RecurrenceStore>;
 const mockApi = JoplinAPI as jest.Mocked<typeof JoplinAPI>;
+
+/**
+ * Sets the `resetAlarmWhenNotDone` setting for a test while leaving every other setting (notably
+ * `debug`, which drives @Trace) off.
+ */
+function setResetAlarmWhenNotDone(enabled: boolean): void {
+  (joplin.settings.value as jest.Mock).mockImplementation(
+    async (key: string) => (key === 'resetAlarmWhenNotDone' ? enabled : false)
+  );
+}
+
+/** Milliseconds offset from now, for time-relative test fixtures. */
+function fromNow(ms: number): number {
+  return Date.now() + ms;
+}
+
+const ONE_HOUR = 60 * 60 * 1000;
 
 /** Build an enabled daily recurrence (optionally overridden). */
 function dailyRecurrence(overrides: Partial<Recurrence> = {}): Recurrence {
@@ -49,6 +67,8 @@ beforeEach(() => {
   mockApi.markTaskIncomplete.mockResolvedValue(undefined);
   mockApi.markSubTasksIncomplete.mockResolvedValue(undefined);
   mockApi.markTaskComplete.mockResolvedValue(undefined);
+  // Default to the old behaviour; the alarm-reset tests opt in explicitly.
+  setResetAlarmWhenNotDone(false);
   // Reset the static re-entrancy guard between tests.
   (RecurrenceManager as any).updating = false;
 });
@@ -72,7 +92,7 @@ describe('RecurrenceManager.updateAllRecurrences (sweep)', () => {
     expect(mockStore.remove).not.toHaveBeenCalled();
   });
 
-  it('does not advance a todo that is not completed', async () => {
+  it('does not advance an incomplete todo when alarm reset is off', async () => {
     const todo = makeTodo({ todo_completed: 0 });
     mockStore.getAllRecurringTodos.mockResolvedValue([todo]);
 
@@ -174,7 +194,7 @@ describe('RecurrenceManager.handleAlarm', () => {
     expect(mockApi.setTaskDueDate).toHaveBeenCalledTimes(1);
   });
 
-  it('no-ops when the alarmed todo is not completed', async () => {
+  it('no-ops on an incomplete todo when alarm reset is off', async () => {
     mockApi.getNote.mockResolvedValue({
       id: 'note-1',
       is_todo: 1,
@@ -186,6 +206,115 @@ describe('RecurrenceManager.handleAlarm', () => {
     await RecurrenceManager.handleAlarm('note-1');
 
     expect(mockApi.setTaskDueDate).not.toHaveBeenCalled();
+  });
+});
+
+describe('RecurrenceManager alarm reset (resetAlarmWhenNotDone)', () => {
+  /** An incomplete todo whose alarm went off an hour ago. */
+  function overdueOpenNote(overrides: Record<string, any> = {}) {
+    return {
+      id: 'note-1',
+      title: 'Test todo',
+      is_todo: 1,
+      todo_due: fromNow(-ONE_HOUR),
+      todo_completed: 0,
+      ...overrides,
+    };
+  }
+
+  it('re-arms the alarm on the next occurrence without completing the todo', async () => {
+    setResetAlarmWhenNotDone(true);
+    const note = overdueOpenNote();
+    mockApi.getNote.mockResolvedValue(note);
+    const recurrence = dailyRecurrence();
+    mockStore.get.mockResolvedValue(recurrence);
+
+    await RecurrenceManager.handleAlarm('note-1');
+
+    expect(mockApi.setTaskDueDate).toHaveBeenCalledTimes(1);
+    const [calledId, calledDate] = mockApi.setTaskDueDate.mock.calls[0];
+    expect(calledId).toBe('note-1');
+    // Daily recurrence, one hour overdue → tomorrow, same time of day.
+    const expected = new Date(note.todo_due);
+    expected.setDate(expected.getDate() + 1);
+    expect((calledDate as Date).getTime()).toBe(expected.getTime());
+    // The to-do was never done, so its state and its sub-tasks are left alone.
+    expect(mockApi.markTaskIncomplete).not.toHaveBeenCalled();
+    expect(mockApi.markSubTasksIncomplete).not.toHaveBeenCalled();
+    expect(mockStore.set).toHaveBeenCalledWith('note-1', recurrence);
+  });
+
+  it('skips past every missed occurrence so the new alarm is in the future', async () => {
+    setResetAlarmWhenNotDone(true);
+    // Hourly recurrence that was last due three and a half hours ago.
+    const dueAt = fromNow(-3.5 * ONE_HOUR);
+    mockApi.getNote.mockResolvedValue(overdueOpenNote({ todo_due: dueAt }));
+    mockStore.get.mockResolvedValue(dailyRecurrence({ interval: 'hour' }));
+
+    await RecurrenceManager.handleAlarm('note-1');
+
+    const [, calledDate] = mockApi.setTaskDueDate.mock.calls[0];
+    expect((calledDate as Date).getTime()).toBeGreaterThan(Date.now());
+    // Four hourly steps from the original due date clears "now" by half an hour.
+    expect((calledDate as Date).getTime()).toBe(dueAt + 4 * ONE_HOUR);
+  });
+
+  it('leaves a todo alone when its alarm has not fired yet', async () => {
+    setResetAlarmWhenNotDone(true);
+    mockApi.getNote.mockResolvedValue(overdueOpenNote({ todo_due: fromNow(ONE_HOUR) }));
+    mockStore.get.mockResolvedValue(dailyRecurrence());
+
+    await RecurrenceManager.handleAlarm('note-1');
+
+    expect(mockApi.setTaskDueDate).not.toHaveBeenCalled();
+    expect(mockStore.set).not.toHaveBeenCalled();
+  });
+
+  it('leaves a todo with no due date alone', async () => {
+    setResetAlarmWhenNotDone(true);
+    mockApi.getNote.mockResolvedValue(overdueOpenNote({ todo_due: 0 }));
+    mockStore.get.mockResolvedValue(dailyRecurrence());
+
+    await RecurrenceManager.handleAlarm('note-1');
+
+    expect(mockApi.setTaskDueDate).not.toHaveBeenCalled();
+  });
+
+  it('catches alarms missed while Joplin was closed via the safety-net sweep', async () => {
+    setResetAlarmWhenNotDone(true);
+    const todo = makeTodo({ todo_due: fromNow(-ONE_HOUR), todo_completed: 0 });
+    mockStore.getAllRecurringTodos.mockResolvedValue([todo]);
+
+    await RecurrenceManager.updateAllRecurrences();
+
+    expect(mockApi.setTaskDueDate).toHaveBeenCalledTimes(1);
+    expect(mockApi.markTaskIncomplete).not.toHaveBeenCalled();
+  });
+
+  it('consumes an occurrence of a stop-after-N recurrence when the alarm is skipped', async () => {
+    setResetAlarmWhenNotDone(true);
+    const recurrence = dailyRecurrence({ stopType: 'number', stopNumber: 1 });
+    mockApi.getNote.mockResolvedValue(overdueOpenNote());
+    mockStore.get.mockResolvedValue(recurrence);
+
+    await RecurrenceManager.handleAlarm('note-1');
+
+    expect(mockApi.setTaskDueDate).toHaveBeenCalledTimes(1);
+    expect(recurrence.enabled).toBe(false);
+    expect(mockStore.remove).toHaveBeenCalledWith('note-1');
+  });
+
+  it('defaults to on when the setting cannot be read', async () => {
+    (joplin.settings.value as jest.Mock).mockImplementation(async (key: string) => {
+      if (key === 'resetAlarmWhenNotDone') throw new Error('setting not registered');
+      return false;
+    });
+    mockApi.getNote.mockResolvedValue(overdueOpenNote());
+    mockStore.get.mockResolvedValue(dailyRecurrence());
+
+    await RecurrenceManager.handleAlarm('note-1');
+
+    expect(mockApi.setTaskDueDate).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
A repeating to-do previously only moved on when it was ticked off, so an
alarm that passed while the to-do was still open left it overdue forever.

Advancement now also happens when an occurrence passes on an open to-do:
the alarm is re-armed on the next occurrence, while the to-do stays open
and its sub-tasks keep their progress (both of which are only reset on
the completion path). If several occurrences were missed - Joplin closed
over the weekend, say - the to-do is skipped forward far enough that the
new alarm lands in the future. Like completions, a skipped occurrence
counts against a stop-after-N recurrence.

Controlled by the new `resetAlarmWhenNotDone` setting, on by default;
turning it off restores the completion-only behaviour. The setting reader
defaults to true so an unreadable value keeps the documented default.

handleAlarm now delegates straight to handleNoteChange, since processTodo
covers both the completed and the open case.

The overdue-completion e2e test could no longer observe its old
behaviour (the past alarm is now rolled forward before the to-do can be
completed), so it is rewritten to assert the reset path instead; the
completion test uses a future alarm to stay out of its way.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FHr1RBvoL1LZ1SHk1heyQ4