### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,15 @@
 name: Publish to npm
 
 # Publishes the plugin package to npm. Runs when a GitHub Release is published, or manually.
-# Requires a repository secret named NPM_TOKEN (an npm automation token with publish rights).
+#
+# Auth is npm "trusted publishing" (OIDC): no NPM_TOKEN secret is used or needed. The job exchanges
+# a short-lived GitHub OIDC token for npm publish rights. One-time setup on npmjs.com:
+#   package page → Settings → Trusted publishers → GitHub Actions
+#   Organization or user: TheScriptingGuy
+#   Repository:           Joplin-Repeating-Todos-Plugin
+#   Workflow filename:    publish.yml
+#   Environment:          npm            (must match the `environment:` below)
+# Once that is configured, any NPM_TOKEN repository secret can be deleted.
 on:
   release:
     types: [published]
@@ -11,19 +19,29 @@ jobs:
   publish:
     name: Build & publish to npm
     runs-on: ubuntu-24.04
+    # Must match the environment name registered on the npm trusted publisher. It also lets you gate
+    # publishes behind required reviewers / branch rules via the repo's Settings → Environments.
+    environment: npm
     permissions:
       contents: read
-      # Enables npm provenance attestations (optional; see the publish step).
+      # Required: lets the job mint the OIDC token npm exchanges for publish rights (and provenance).
       id-token: write
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
-          # Writes an .npmrc pointing at the public registry and wires NODE_AUTH_TOKEN for auth.
+          # Writes an .npmrc pointing at the public registry. Still needed for OIDC: the registry
+          # must be registry.npmjs.org for npm to attempt the trusted-publishing token exchange.
           registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing requires npm >= 11.5.1; Node 22 still ships npm 10.x, so upgrade first.
+      - name: Upgrade npm (trusted publishing support)
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       # Resolve the version to publish: on a Release, take it from the tag (e.g. v1.2.0 -> 1.2.0);
       # otherwise (manual workflow_dispatch) use the existing package.json version. The resolved
@@ -53,14 +71,11 @@ jobs:
       # Build the publishable artifact (webpack -> ./publish, the only dir in package.json "files").
       - run: npm run dist
 
-      # NPM_TOKEN must be an Automation token (not a Publish token). Automation tokens bypass the
-      # OTP/2FA requirement that causes "npm error code EOTP" in CI. Create one at:
-      # npmjs.com → profile → Access Tokens → Generate New Token → Automation
-      # publishConfig.access is already "public" in package.json. --ignore-scripts avoids rebuilding
-      # via the "prepare" hook since we just built above.
+      # No NODE_AUTH_TOKEN: npm detects the Actions OIDC environment and exchanges an id-token for a
+      # short-lived publish credential. Provenance attestations are generated automatically for
+      # trusted publishes, so --provenance is not passed. publishConfig.access is already "public" in
+      # package.json. --ignore-scripts avoids rebuilding via the "prepare" hook since we just built above.
       - name: Publish to npm
         run: |
           echo "Publishing $(node -p "require('./package.json').name")@$PUBLISH_VERSION"
-          npm publish --provenance --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm publish --ignore-scripts


### PR DESCRIPTION
Switches `.github/workflows/publish.yml` from `NPM_TOKEN` automation-token auth to npm [trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC).

## Changes

- **`environment: npm`** on the publish job — matches the environment registered on the npm trusted publisher, and lets publishes be gated behind reviewers/branch rules via Settings → Environments.
- **Removed `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN`** from the publish step. npm detects the Actions OIDC context and exchanges the job's id-token for a short-lived publish credential. The existing `id-token: write` permission is now load-bearing rather than optional.
- **Node 20 → 22, plus `npm install -g npm@latest`.** Trusted publishing requires npm >= 11.5.1; both Node 20 and 22 still bundle npm 10.x, so the explicit upgrade step is required.
- **Dropped `--provenance`** — provenance attestations are generated automatically for trusted publishes.

`registry-url: 'https://registry.npmjs.org'` is kept: the registry must resolve to registry.npmjs.org or npm won't attempt the token exchange. Version resolution, `npm test`, and `npm run dist` steps are unchanged.

## Setup

The trusted publisher has been configured on npmjs.com (owner `TheScriptingGuy`, repo `Joplin-Repeating-Todos-Plugin`, workflow `publish.yml`, environment `npm`).

Remaining before the next release:
- Create the `npm` environment under the repo's Settings → Environments if it doesn't exist yet.
- The `NPM_TOKEN` repository secret is no longer read by this workflow and can be deleted.

## Testing

YAML parses cleanly. The publish path itself is only exercised on a real Release or `workflow_dispatch` run, so the first release after merge is the actual verification.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfMX5a5kQxLWys8ju2rECF)_