### PR TITLE
fix: make the alarm reset a per-to-do option instead of a global one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Add a "Remove all recurrence settings from all to-dos" toggle to the plugin settings: a confirmed one-shot action that clears the recurrence settings of every to-do at once and then switches itself back off. To-dos keep their alarms, contents and completion state - they just stop repeating
 - Reset the alarm of a repeating to-do that was never marked done: when an occurrence passes, the alarm is re-armed on the next one, the to-do stays open and its sub-tasks keep their progress. This is a per-to-do option ("Move the alarm on even when this To-Do is not done") in the recurrence dialog and is off by default, so it never changes to-dos you did not tick it on — including every recurrence created before the option existed
 - Store recurrence settings in Joplin note userData (synchronised, invisible) instead of YAML frontmatter in the note body; one-time automatic migration of existing frontmatter
 - Drive recurrence from Joplin's to-do alarm: advance the alarm/due date on completion via note-change and alarm-trigger events, with a periodic sweep as a safety net

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- Reset the alarm of a repeating to-do that was never marked done: when an occurrence passes, the alarm is re-armed on the next one, the to-do stays open and its sub-tasks keep their progress. Controlled by the new "Reset the alarm even when the to-do is not done" setting, which is on by default — turn it off for the previous completion-only behaviour
+- Reset the alarm of a repeating to-do that was never marked done: when an occurrence passes, the alarm is re-armed on the next one, the to-do stays open and its sub-tasks keep their progress. This is a per-to-do option ("Move the alarm on even when this To-Do is not done") in the recurrence dialog and is off by default, so it never changes to-dos you did not tick it on — including every recurrence created before the option existed
 - Store recurrence settings in Joplin note userData (synchronised, invisible) instead of YAML frontmatter in the note body; one-time automatic migration of existing frontmatter
 - Drive recurrence from Joplin's to-do alarm: advance the alarm/due date on completion via note-change and alarm-trigger events, with a periodic sweep as a safety net
 - Fix `getNextDateAfter` (it never returned a value) and overdue-todo handling

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A powerful and comprehensive plugin for to-do repetition/recurrence in [Joplin](
 
 ## Overview
 
-When a recurring to-do is marked complete, this plugin immediately resets the alarm date to the next recurrence and unmarks it as completed — so your to-do list is always up to date without any manual work. To-dos you *don't* get around to are not left behind either: by default a passed alarm is simply re-armed on the next occurrence, and you can [switch that off](#plugin-settings) if you would rather they stay overdue.
+When a recurring to-do is marked complete, this plugin immediately resets the alarm date to the next recurrence and unmarks it as completed — so your to-do list is always up to date without any manual work. To-dos you *don't* get around to need not be left behind either: tick [one option](#resetting-the-alarm-without-completing-the-to-do) on a to-do and a passed alarm is simply re-armed on the next occurrence instead of sitting there overdue.
 
 Supported recurrence intervals: **minute, hour, day, week, month, year**
 
@@ -107,7 +107,7 @@ When **months** is selected, you can specify a particular weekday of the month (
 
 #### Step 7 — Save
 
-Click **OK** to save. The recurrence is now active. It reschedules automatically the next time you mark the to-do complete — or, unless you turn that off in the [plugin settings](#plugin-settings), the next time its alarm passes without it being done.
+Click **OK** to save. The recurrence is now active. It reschedules automatically the next time you mark the to-do complete — or, if you ticked **Move the alarm on even when this To-Do is not done** for this to-do, the next time its alarm passes without it being done.
 
 ---
 
@@ -121,10 +121,10 @@ Access these options from **Tools → Repeating To-dos**:
 | **Update Overdue To-Dos** | Marks overdue to-dos complete and rolls their due date forward to the next occurrence past today |
 | **Reschedule Overdue To-Dos to Today** | Keeps the to-dos open but moves their due date to today (preserving the original time-of-day) |
 
-> With **Reset the alarm even when the to-do is not done** on (the default), overdue repeating
-> to-dos are already moved on automatically, so these commands are mostly a manual nudge. Note that
-> *Reschedule Overdue To-Dos to Today* can land on a time that has already passed today, in which
-> case the next automatic reset moves it on again.
+> To-dos that have **Move the alarm on even when this To-Do is not done** ticked are already moved
+> on automatically, so for those these commands are mostly a manual nudge. Note that *Reschedule
+> Overdue To-Dos to Today* can land on a time that has already passed today, in which case the next
+> automatic reset moves such a to-do on again.
 
 ### Plugin Settings
 
@@ -133,15 +133,20 @@ Go to **Tools → Options → Repeating To-dos** to configure:
 | Setting | Default | Description |
 |---|---|---|
 | Update frequency (seconds) | 30 | How often the safety-net sweep checks for missed recurring to-dos |
-| Reset the alarm even when the to-do is not done | **On** | Re-arms the alarm on the next occurrence when one passes without the to-do being completed. Turn it off to only advance to-dos when they are ticked off (the previous behaviour) |
 | Enable debug logging | Off | Writes detailed trace output to the developer console |
+
+There is deliberately no global switch for the alarm-reset behaviour below: it is set per to-do in
+the recurrence dialog, so turning it on for one to-do never changes any of the others.
 
 #### Resetting the alarm without completing the to-do
 
-By default, a repeating to-do no longer waits to be ticked off before it moves on. When its alarm
-passes while the to-do is still open, the plugin skips that occurrence and re-arms the alarm on the
-next one — so a "water the plants every day" reminder pops up again tomorrow instead of sitting
-overdue forever.
+**Move the alarm on even when this To-Do is not done** is an option on each individual to-do, in the
+recurrence dialog, and it is **off by default**. Off, a repeating to-do behaves like any other
+to-do: once its alarm passes it stays overdue until you tick it off.
+
+Tick it for a to-do and, when its alarm passes while the to-do is still open, the plugin skips that
+occurrence and re-arms the alarm on the next one — so a "water the plants every day" reminder pops
+up again tomorrow instead of sitting overdue forever. Only the to-dos you tick it on are affected.
 
 On the reset path the plugin deliberately does **less** than it does on completion:
 
@@ -156,8 +161,8 @@ If several occurrences were missed — Joplin was closed over the weekend, say �
 forward far enough that the new alarm always lands in the future. Missed alarms are caught by the
 alarm event when Joplin is running, and by the safety-net sweep on startup when it was not.
 
-Turn the setting off in **Tools → Options → Repeating To-dos** to get the old behaviour, where an
-overdue to-do stays overdue until you complete it.
+Leave the option unticked — the default, including for every recurrence created before the option
+existed — to keep the plain behaviour, where an overdue to-do stays overdue until you complete it.
 
 ---
 
@@ -165,8 +170,8 @@ overdue to-do stays overdue until you complete it.
 
 ### Scheduling Flow
 
-Two things move a recurring to-do on to its next occurrence: completing it, or — with **Reset the
-alarm even when the to-do is not done** enabled (the default) — its alarm passing while it is still
+Two things move a recurring to-do on to its next occurrence: completing it, or — for a to-do with
+**Move the alarm on even when this To-Do is not done** ticked — its alarm passing while it is still
 open.
 
 When you mark a recurring to-do as complete, the plugin immediately:
@@ -188,7 +193,7 @@ flowchart TD
     B -- Yes --> D{Has a\ndue date set?}
     D -- No --> C
     D -- Yes --> Q{Marked\ncomplete?}
-    Q -- No --> R{Alarm passed and\nalarm reset enabled?}
+    Q -- No --> R{Alarm passed and\nthis to-do opted in?}
     R -- No --> S([Leave it alone\nwaits for completion])
     R -- Yes --> T[Calculate first occurrence\nstrictly in the future]
     T --> F
@@ -284,7 +289,7 @@ flowchart TD
 
     H --> M{Recurrence\nconditions met?}
     M -- Completed --> N([Advance due date\nunmark complete\nreset sub-tasks])
-    M -- Alarm passed,\nnot done --> P([Advance due date only\nto-do stays open])
+    M -- Alarm passed, not done,\nto-do opted in --> P([Advance due date only\nto-do stays open])
     M -- Neither --> O([Skip])
 
     style N fill:#d4edda

--- a/README.md
+++ b/README.md
@@ -134,9 +134,22 @@ Go to **Tools → Options → Repeating To-dos** to configure:
 |---|---|---|
 | Update frequency (seconds) | 30 | How often the safety-net sweep checks for missed recurring to-dos |
 | Enable debug logging | Off | Writes detailed trace output to the developer console |
+| Remove all recurrence settings from all to-dos | Off | A one-shot action: switch it on to clear the recurrence settings of every to-do at once. See below |
 
-There is deliberately no global switch for the alarm-reset behaviour below: it is set per to-do in
-the recurrence dialog, so turning it on for one to-do never changes any of the others.
+There is deliberately no global switch for the alarm-reset behaviour: it is set per to-do in the
+recurrence dialog (see [Resetting the alarm without completing the
+to-do](#resetting-the-alarm-without-completing-the-to-do)), so turning it on for one to-do never
+changes any of the others.
+
+#### Removing all recurrence settings at once
+
+Switching **Remove all recurrence settings from all to-dos** on clears the recurrence dialog
+settings of every to-do in one go. The plugin asks for confirmation first, then reports how many
+to-dos it cleared, and the switch turns itself back off — it is an action, not a state you leave on.
+
+What it removes is only what the recurrence dialog stores. Your to-dos are kept exactly as they are:
+alarms, contents, sub-tasks and completion state are all untouched; they simply stop repeating. The
+removed recurrence settings cannot be restored afterwards, so use it when you want a clean slate.
 
 #### Resetting the alarm without completing the to-do
 
@@ -383,10 +396,10 @@ Enable **debug logging** in **Tools → Options → Repeating To-dos** to see de
 
 | Class | Responsibility |
 |---|---|
-| `RecurrenceStore` | Reads/writes recurrence settings to Joplin's `userData` API per note; maintains the `recurring` index tag |
+| `RecurrenceStore` | Reads/writes recurrence settings to Joplin's `userData` API per note; maintains the `recurring` index tag; can clear the whole index in one go |
 | `RecurrenceManager` | Core logic: processes a completed to-do (or a passed alarm on an open one), computes the next date, advances the alarm, handles overdue scenarios |
 | `RecurrenceScheduler` | Wires up `onNoteChange` and `onNoteAlarmTrigger` Joplin events; runs a periodic safety-net sweep |
-| `SettingsManager` | Registers the plugin settings section and restarts the scheduler when settings change |
+| `SettingsManager` | Registers the plugin settings section, restarts the scheduler when settings change, and runs the one-shot "remove all recurrence settings" toggle |
 | `CommandManager` | Registers the four Joplin commands exposed in the toolbar and menu |
 | `Recurrence` (model) | Holds all recurrence fields; implements `getNextDate`, `getNextDateAfter`, `updateStopStatus` |
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -90,6 +90,8 @@ export interface RecurrenceConfig {
     'sunday' | 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday'
   >;
   stop?: RecurrenceStop;
+  /** Tick the per-to-do "move the alarm on even when this To-Do is not done" option. */
+  resetAlarmWhenNotDone?: boolean;
 }
 
 const WEEKDAY_IDS: Record<string, string> = {
@@ -139,6 +141,9 @@ export async function setRecurrence(win: Page, config: RecurrenceConfig): Promis
         await setCheckbox(frame, id, config.weekdays.includes(name as any));
       }
     }
+    if (config.resetAlarmWhenNotDone != null) {
+      await setCheckbox(frame, '#resetAlarmCheckbox', config.resetAlarmWhenNotDone);
+    }
     if (config.stop) {
       await frame.locator('#stopTypeDropdown').selectOption(config.stop.type);
       if (config.stop.type === 'number' && config.stop.number != null) {
@@ -163,6 +168,7 @@ export interface RecurrenceState {
   intervalNumber: string;
   weekdays: Record<string, boolean>;
   stopType: string;
+  resetAlarmWhenNotDone: boolean;
 }
 
 /**
@@ -176,6 +182,7 @@ export async function readRecurrenceDialog(win: Page): Promise<RecurrenceState> 
   const interval = await frame.locator('#intervalDropdown').inputValue();
   const intervalNumber = await frame.locator('#intervalNumberSpinbutton').inputValue();
   const stopType = await frame.locator('#stopTypeDropdown').inputValue();
+  const resetAlarmWhenNotDone = await frame.locator('#resetAlarmCheckbox').isChecked();
 
   const weekdays: Record<string, boolean> = {};
   for (const [name, id] of Object.entries(WEEKDAY_IDS)) {
@@ -186,7 +193,7 @@ export async function readRecurrenceDialog(win: Page): Promise<RecurrenceState> 
   await win.locator('button:has-text("Cancel")').last().click();
   await win.waitForTimeout(SETTLE);
 
-  return { enabled, interval, intervalNumber, weekdays, stopType };
+  return { enabled, interval, intervalNumber, weekdays, stopType, resetAlarmWhenNotDone };
 }
 
 /** ----------------------------------------------------------------------------------------------

--- a/e2e/recurrence-advance.spec.ts
+++ b/e2e/recurrence-advance.spec.ts
@@ -47,8 +47,8 @@ test.describe('Recurrence advancement', () => {
     const { win } = joplin;
     await createTodo(win, 'Advance Todo ' + Date.now());
 
-    // Deliberately in the future: an alarm that has already passed would be rolled forward by the
-    // "reset alarm when not done" behaviour before we get to complete it (see the next test).
+    // Deliberately in the future so the completion path is what is observed here (an already-passed
+    // alarm is only rolled forward when this to-do opts in — see the last test).
     const ORIGINAL = alarmString(daysFromNow(30));
     const EXPECTED = alarmString(daysFromNow(31));
 
@@ -77,14 +77,18 @@ test.describe('Recurrence advancement', () => {
     const { win } = joplin;
     await createTodo(win, 'Overdue Todo ' + Date.now());
 
-    // Alarm well in the past — the missed-occurrence path. With the default
-    // `resetAlarmWhenNotDone` setting the plugin re-arms the alarm on the next occurrence without
-    // the to-do ever being ticked off. The alarm event already fired long ago, so what picks this
-    // up is the periodic safety-net sweep (default every 30 s).
+    // Alarm well in the past — the missed-occurrence path. With this to-do's own
+    // "move the alarm on even when not done" option ticked, the plugin re-arms the alarm on the
+    // next occurrence without the to-do ever being ticked off. The alarm event already fired long
+    // ago, so what picks this up is the periodic safety-net sweep (default every 30 s).
     const ORIGINAL = '2020-03-10T08:00';
 
     await setAlarm(win, ORIGINAL);
-    await setRecurrence(win, { enabled: true, interval: 'day' });
+    await setRecurrence(win, {
+      enabled: true,
+      interval: 'day',
+      resetAlarmWhenNotDone: true,
+    });
 
     await expect
       .poll(async () => readAlarm(win), { timeout: 90_000, intervals: [2000] })
@@ -99,6 +103,24 @@ test.describe('Recurrence advancement', () => {
     );
 
     // KEY ASSERTION: the to-do was never marked complete along the way — only the alarm moved.
+    expect(await isTodoComplete(win)).toBe(false);
+  });
+
+  test('an OVERDUE recurring to-do that did NOT opt in keeps its alarm until it is done', async () => {
+    const { win } = joplin;
+    await createTodo(win, 'Overdue Untouched Todo ' + Date.now());
+
+    // Same setup as the test above, minus the per-to-do opt-in. The alarm must stay put: the
+    // alarm reset is a choice made per to-do, never something applied to every repeating to-do.
+    const ORIGINAL = '2020-03-10T08:00';
+
+    await setAlarm(win, ORIGINAL);
+    await setRecurrence(win, { enabled: true, interval: 'day' });
+
+    // Well past the safety-net sweep interval (default 30 s), so a sweep has definitely run.
+    await win.waitForTimeout(60_000);
+
+    expect(await readAlarm(win)).toBe(ORIGINAL);
     expect(await isTodoComplete(win)).toBe(false);
   });
 });

--- a/e2e/recurrence-dialog.spec.ts
+++ b/e2e/recurrence-dialog.spec.ts
@@ -57,4 +57,22 @@ test.describe('Recurrence dialog round-trip', () => {
     state = await readRecurrenceDialog(win);
     expect(state.enabled).toBe(false);
   });
+
+  test('the alarm-reset option is off by default and stays per to-do', async () => {
+    const { win } = joplin;
+
+    // A to-do that opts in.
+    await createTodo(win, 'Opted In Todo ' + Date.now());
+    await setRecurrence(win, {
+      enabled: true,
+      interval: 'day',
+      resetAlarmWhenNotDone: true,
+    });
+    expect((await readRecurrenceDialog(win)).resetAlarmWhenNotDone).toBe(true);
+
+    // A second to-do set up the same way, minus that option, must not inherit it.
+    await createTodo(win, 'Plain Todo ' + Date.now());
+    await setRecurrence(win, { enabled: true, interval: 'day' });
+    expect((await readRecurrenceDialog(win)).resetAlarmWhenNotDone).toBe(false);
+  });
 });

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -113,9 +113,15 @@ export class RecurrenceStore {
   @Trace()
   @TryCatch({ logError: true })
   static async remove(noteId: string): Promise<void> {
+    await this.removeUsingTag(await this.findOrCreateTagId(), noteId);
+  }
+
+  /** removeUsingTag ***********************************************************************************************************************
+   * The body of `remove` with the index tag already resolved, so bulk callers look it up only once.                                       *
+   *************************************************************************************************************************************/
+  private static async removeUsingTag(tagId: string | null, noteId: string): Promise<void> {
     await joplin.data.userDataDelete(ModelType.Note, noteId, this.RECURRENCE_KEY);
 
-    const tagId = await this.findOrCreateTagId();
     if (tagId) {
       try {
         await joplin.data.delete(["tags", tagId, "notes", noteId]);
@@ -135,19 +141,13 @@ export class RecurrenceStore {
     const tagId = await this.findOrCreateTagId();
     if (!tagId) return [];
 
-    const notes: any[] = [];
-    let page = 1;
-    let hasMore = true;
-    while (hasMore) {
-      const response = await joplin.data.get(["tags", tagId, "notes"], {
-        fields: ["id", "title", "is_todo", "todo_due", "todo_completed"],
-        page,
-      });
-      const items = response?.items || [];
-      notes.push(...items);
-      hasMore = Boolean(response?.has_more);
-      page += 1;
-    }
+    const notes = await this.getIndexedNotes(tagId, [
+      "id",
+      "title",
+      "is_todo",
+      "todo_due",
+      "todo_completed",
+    ]);
 
     const results: RecurringTodo[] = [];
     for (const note of notes) {
@@ -172,6 +172,45 @@ export class RecurrenceStore {
     }
 
     return results;
+  }
+
+  /** removeAll ****************************************************************************************************************************
+   * Wipes the recurrence data off every note in the recurring index, leaving the notes themselves   *
+   * (and their alarms) untouched. Returns how many notes were cleared.                              *
+   * Unlike getAllRecurringTodos this does not skip non-to-do notes, so nothing is left behind.     *
+   *************************************************************************************************************************************/
+  @Trace()
+  @TryCatch({ logError: true, fallback: 0 })
+  static async removeAll(): Promise<number> {
+    const tagId = await this.findOrCreateTagId();
+    if (!tagId) return 0;
+
+    const notes = await this.getIndexedNotes(tagId, ["id"]);
+    for (const note of notes) {
+      await this.removeUsingTag(tagId, note.id);
+    }
+
+    return notes.length;
+  }
+
+  /** getIndexedNotes **********************************************************************************************************************
+   * Returns every note carrying the `recurring` index tag, walking all pages of the tag query.      *
+   *************************************************************************************************************************************/
+  private static async getIndexedNotes(tagId: string, fields: string[]): Promise<any[]> {
+    const notes: any[] = [];
+    let page = 1;
+    let hasMore = true;
+    while (hasMore) {
+      const response = await joplin.data.get(["tags", tagId, "notes"], {
+        fields,
+        page,
+      });
+      const items = response?.items || [];
+      notes.push(...items);
+      hasMore = Boolean(response?.has_more);
+      page += 1;
+    }
+    return notes;
   }
 
   /** extractLegacyFrontmatter *************************************************************************************************************

--- a/src/core/recurrence.ts
+++ b/src/core/recurrence.ts
@@ -135,9 +135,10 @@ export class RecurrenceManager {
 
   /**
    * Event hook: an alarm fired for a note. A completed to-do advances exactly as it would on a
-   * note-change; an open one is rolled on to its next occurrence when the `resetAlarmWhenNotDone`
-   * setting is on (the default), which re-arms the alarm without the to-do ever being ticked off.
-   * Both cases are handled by `processTodo`, so the alarm is just another way in.
+   * note-change; an open one is rolled on to its next occurrence only when that to-do has
+   * `resetAlarmWhenNotDone` set on its own recurrence, which re-arms the alarm without the to-do
+   * ever being ticked off. Both cases are handled by `processTodo`, so the alarm is just another
+   * way in.
    */
   @Trace()
   @TryCatch({ logError: true })
@@ -150,9 +151,10 @@ export class RecurrenceManager {
    *
    * Two paths advance a to-do to its next occurrence:
    *  - completion — the to-do was ticked off. It is reopened and its sub-tasks are reset.
-   *  - alarm reset — the due date/alarm passed while the to-do was still open, and
-   *    `resetAlarmWhenNotDone` is enabled. The missed occurrence is skipped and the alarm re-armed
-   *    on the next one; the to-do stays open and any sub-task progress is left untouched.
+   *  - alarm reset — the due date/alarm passed while the to-do was still open, and this to-do's
+   *    recurrence has `resetAlarmWhenNotDone` ticked. The missed occurrence is skipped and the
+   *    alarm re-armed on the next one; the to-do stays open and any sub-task progress is left
+   *    untouched. Off by default, so a repeating to-do that is not done stays overdue.
    *
    * Both paths consume one occurrence, so a stop-after-N recurrence counts skipped alarms too.
    */
@@ -170,10 +172,11 @@ export class RecurrenceManager {
     const now = new Date();
 
     if (!completed) {
-      // An open to-do only moves on once its alarm has actually passed, and only if the user has
-      // left the alarm-reset setting on.
+      // An open to-do only moves on once its alarm has actually passed, and only when this
+      // particular to-do was set up to have its alarm reset. Every other repeating to-do stays
+      // overdue until it is ticked off.
+      if (!recurrence.resetAlarmWhenNotDone) return;
       if (todo.todo_due > now.getTime()) return;
-      if (!(await this.resetAlarmWhenNotDone())) return;
     }
 
     const initialDate = new Date(todo.todo_due);
@@ -201,19 +204,6 @@ export class RecurrenceManager {
     } else {
       // The recurrence just hit its stop condition; drop it from the index.
       await RecurrenceStore.remove(todo.id);
-    }
-  }
-
-  /**
-   * Reads the `resetAlarmWhenNotDone` setting. Defaults to true so an unreadable or not-yet-
-   * registered value keeps the documented default behaviour.
-   */
-  private static async resetAlarmWhenNotDone(): Promise<boolean> {
-    try {
-      const value = await joplin.settings.value('resetAlarmWhenNotDone');
-      return value === undefined || value === null ? true : Boolean(value);
-    } catch {
-      return true;
     }
   }
 }

--- a/src/core/recurrence.ts
+++ b/src/core/recurrence.ts
@@ -60,6 +60,37 @@ export class RecurrenceManager {
     }
   }
 
+  /**
+   * Wipe the recurrence settings off every to-do, after confirming with the user.
+   *
+   * This only clears what the recurrence dialog stores (the userData entry and the `recurring`
+   * index tag). The to-dos themselves are left alone: their alarms, completion state and sub-tasks
+   * are untouched — they simply stop repeating. There is no undo, hence the confirmation.
+   *
+   * Returns the number of to-dos cleared, or -1 when the user cancelled.
+   */
+  @Trace()
+  @TryCatch({ logError: true, fallback: -1 })
+  static async clearAllRecurrences(): Promise<number> {
+    const confirmed = await joplin.views.dialogs.showMessageBox(
+      'Remove the recurrence settings from every to-do?\n\n' +
+        'All to-dos will stop repeating. Their alarms and contents are left as they are, but the ' +
+        'recurrence settings cannot be restored afterwards.'
+    );
+    // showMessageBox returns 0 for OK and 1 for Cancel.
+    if (confirmed !== 0) return -1;
+
+    const cleared = await RecurrenceStore.removeAll();
+
+    await joplin.views.dialogs.showMessageBox(
+      cleared === 0
+        ? 'No to-dos had recurrence settings to remove.'
+        : `Recurrence settings removed from ${cleared} to-do${cleared === 1 ? '' : 's'}.`
+    );
+
+    return cleared;
+  }
+
   /** Move overdue todos to today (preserve time-of-day). */
   @Trace()
   @TryCatch({ logError: true })

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -32,18 +32,6 @@ export class SettingsManager {
         minimum: 10,
         maximum: 3600,
       },
-      resetAlarmWhenNotDone: {
-        label: 'Reset the alarm even when the to-do is not done',
-        description:
-          'When a repeating to-do\'s alarm passes without it being marked as done, re-arm the ' +
-          'alarm on the next occurrence anyway. The to-do stays open and its sub-tasks keep ' +
-          'their progress. Turn this off to only advance repeating to-dos when they are ' +
-          'completed (the previous behaviour).',
-        value: true,
-        type: SettingItemType.Bool,
-        public: true,
-        section: this.SECTION_ID,
-      },
       debug: {
         label: 'Enable debug logging',
         description: 'Logs detailed info to the developer console',

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -1,5 +1,7 @@
 import joplin from 'api';
+import { ChangeEvent } from 'api/JoplinSettings';
 import { SettingItemType } from 'api/types';
+import { RecurrenceManager } from './recurrence';
 import { RecurrenceScheduler } from './timer';
 import { TryCatch } from './decorators';
 
@@ -10,6 +12,10 @@ export class SettingsManager {
   private static readonly SECTION_ID = 'repeating-todos';
   private static readonly SECTION_LABEL = 'Repeating To-dos';
   private static readonly SECTION_ICON = 'fa fa-redo-alt';
+  /** Key of the one-shot "remove everything" toggle. */
+  private static readonly CLEAR_ALL_KEY = 'clearAllRecurrences';
+  /** Guard so the toggle-reset write cannot re-enter the clear routine. */
+  private static clearing = false;
 
   /** Register settings section and individual settings */
   @TryCatch({ logError: true })
@@ -40,14 +46,48 @@ export class SettingsManager {
         public: true,
         section: this.SECTION_ID,
       },
+      [this.CLEAR_ALL_KEY]: {
+        label: 'Remove all recurrence settings from all to-dos',
+        description:
+          'Switch this on to clear the recurrence dialog settings of every to-do at once, after ' +
+          'a confirmation. The to-dos themselves are kept exactly as they are - alarms, contents ' +
+          'and completion state included - they just stop repeating. The switch turns itself back ' +
+          'off once it has run, and what it removes cannot be restored.',
+        value: false,
+        type: SettingItemType.Bool,
+        public: true,
+        section: this.SECTION_ID,
+      },
     });
 
-    // Restart timer whenever settings change
-    joplin.settings.onChange(async () => {
+    // Restart timer whenever settings change, and run the one-shot clear when it is switched on.
+    joplin.settings.onChange(async (event: ChangeEvent) => {
       console.info('Settings changed — restarting scheduler...');
       await RecurrenceScheduler.start();
+      await this.handleClearAllToggle(event);
     });
 
     console.info('Settings registered and change listener attached.');
+  }
+
+  /**
+   * Runs the "remove all recurrence settings" action when its toggle is switched on, then switches
+   * the toggle straight back off so it reads as the momentary action it is. The reset write comes
+   * back through onChange, which the `clearing` guard (and the value check) absorbs.
+   */
+  @TryCatch({ logError: true })
+  private static async handleClearAllToggle(event?: ChangeEvent): Promise<void> {
+    if (this.clearing) return;
+    // Joplin reports which keys changed; ignore changes to anything else.
+    if (event?.keys && !event.keys.includes(this.CLEAR_ALL_KEY)) return;
+    if (!(await joplin.settings.value(this.CLEAR_ALL_KEY))) return;
+
+    this.clearing = true;
+    try {
+      await RecurrenceManager.clearAllRecurrences();
+    } finally {
+      await joplin.settings.setValue(this.CLEAR_ALL_KEY, false);
+      this.clearing = false;
+    }
   }
 }

--- a/src/gui/dialog/dialog.ts
+++ b/src/gui/dialog/dialog.ts
@@ -19,6 +19,12 @@ export async function setupDialog() {  // Named export (no default needed)
         <label for="enabledCheckbox">This To-Do Repeats</label>
     </fieldset>
 
+    <fieldset id="alarmFieldset">
+        <legend>Alarm</legend>
+        <input id="resetAlarmCheckbox" type="checkbox" value="True">
+        <label for="resetAlarmCheckbox">Move the alarm on even when this To-Do is not done</label>
+    </fieldset>
+
     <fieldset id="intervalFieldset">
         <legend>Interval</legend>
         <input id="intervalNumberSpinbutton" type="number" min="1" max="999" step="1" value="1">

--- a/src/gui/dialog/dialog_addon.js
+++ b/src/gui/dialog/dialog_addon.js
@@ -201,6 +201,26 @@ function onIntervalNumberChanged() {
 }
 
 /******************************************************************************************************************************************
+****************************************************************** Alarm ******************************************************************
+******************************************************************************************************************************************/
+let alarmFieldset = safeGetElement('alarmFieldset');           // Gets the alarm Fieldset
+let resetAlarmCheckbox = safeGetElement('resetAlarmCheckbox'); // Gets the "move the alarm on when not done" checkbox
+
+if (resetAlarmCheckbox) {
+    resetAlarmCheckbox.addEventListener("change", onResetAlarmChanged);
+}
+
+/* onResetAlarmChanged ********************************************************************************************************************
+    Called if the reset-alarm checkbox is toggled. Saves the changes to the hidden form. This is a per-to-do option: it only affects the
+    to-do the dialog was opened for.
+*/
+function onResetAlarmChanged() {
+    if (!recurrence || !resetAlarmCheckbox) return;
+    recurrence.resetAlarmWhenNotDone = resetAlarmCheckbox.checked;
+    saveData();
+}
+
+/******************************************************************************************************************************************
  ***************************************************************** Enabled ****************************************************************
 ******************************************************************************************************************************************/
 let enabledCheckbox = safeGetElement('enabledCheckbox');       // Gets the enabled checkbox
@@ -224,12 +244,18 @@ function onEnabledChanged() {
         if (stopFieldset) {
             stopFieldset.style.display = 'block';                             // and the stop Fieldset
         }
+        if (alarmFieldset) {
+            alarmFieldset.style.display = 'block';                            // and the alarm Fieldset
+        }
     } else {                                                            // Otherwise...
         if (intervalFieldset) {
             intervalFieldset.style.display = 'none';                          // Hide the interval Fieldset
         }
         if (stopFieldset) {
             stopFieldset.style.display = 'none';                              // And the stop Fieldset
+        }
+        if (alarmFieldset) {
+            alarmFieldset.style.display = 'none';                             // And the alarm Fieldset
         }
     }
     onIntervalChanged();                                                // Calls the interval changed function for updating
@@ -278,7 +304,8 @@ function loadData() {
                 monthOrdinal: '',
                 stopType: '',
                 stopDate: '',
-                stopNumber: 0
+                stopNumber: 0,
+                resetAlarmWhenNotDone: false
             };
             return;
         }
@@ -301,6 +328,7 @@ function loadData() {
         if (stopTypeDropdown) stopTypeDropdown.value = recurrence.stopType || '';
         if (stopDatePicker) stopDatePicker && (stopDatePicker.value = recurrence.stopDate ? String(recurrence.stopDate) : "");
         if (stopNumberSpinbutton) stopNumberSpinbutton.value = recurrence.stopNumber || 0;
+        if (resetAlarmCheckbox) resetAlarmCheckbox.checked = recurrence.resetAlarmWhenNotDone || false;
 
         onEnabledChanged();
         onIntervalChanged();
@@ -324,7 +352,8 @@ function loadData() {
             monthOrdinal: '',
             stopType: '',
             stopDate: '',
-            stopNumber: 0
+            stopNumber: 0,
+            resetAlarmWhenNotDone: false
         };
     }
 }

--- a/src/model/recurrence.ts
+++ b/src/model/recurrence.ts
@@ -34,6 +34,12 @@
  *      Valid values stop date are null and any datetime object                                                                                     *
  *      Valid values for stopNumber are any positive integer (zero and above)                                                                       *
  *                                                                                                                                                  *
+ *  resetAlarmWhenNotDone                                                                                                                           *
+ *      This boolean decides what happens when an occurrence passes while the to-do is still open. When false (the default) the to-do stays overdue *
+ *      until it is ticked off, which is how a to-do normally behaves. When true the alarm is re-armed on the next occurrence anyway; the to-do     *
+ *      stays open and its sub-tasks keep their progress. It is per-to-do on purpose: a daily habit may want the alarm to move on by itself, while  *
+ *      a task that must actually be done should stay overdue until it is.                                                                     *
+ *                                                                                                                                                  *
  ***************************************************************************************************************************************************/
 
 import { capitalize } from "../core/misc"
@@ -58,6 +64,7 @@ export interface RecurrenceData {
     stopType: string
     stopDate: string | null
     stopNumber: number
+    resetAlarmWhenNotDone: boolean
 }
 
 export class Recurrence {
@@ -78,6 +85,7 @@ export class Recurrence {
     public stopType: string = 'never'
     public stopDate: string | null = null
     public stopNumber: number = 1
+    public resetAlarmWhenNotDone: boolean = false
 
     /** Private Constants **************************************************************************************************************************/
     private weekdayStrings: string[] = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"]
@@ -293,6 +301,7 @@ export function recurrenceToObject(recurrence: Recurrence): RecurrenceData {
         stopType: recurrence.stopType,
         stopDate: recurrence.stopDate,
         stopNumber: recurrence.stopNumber,
+        resetAlarmWhenNotDone: recurrence.resetAlarmWhenNotDone,
     }
 }
 
@@ -320,6 +329,9 @@ export function recurrenceFromObject(data: Partial<RecurrenceData> | null | unde
     if (data.stopType !== undefined) { recurrence.stopType = String(data.stopType) }
     if (data.stopDate !== undefined) { recurrence.stopDate = data.stopDate === null ? null : String(data.stopDate) }
     if (data.stopNumber !== undefined) { recurrence.stopNumber = Number(data.stopNumber) }
+    // Absent on recurrences stored before the option existed, which keeps them on the default: an
+    // open to-do stays overdue until it is ticked off.
+    if (data.resetAlarmWhenNotDone !== undefined) { recurrence.resetAlarmWhenNotDone = Boolean(data.resetAlarmWhenNotDone) }
     return recurrence
 }
 
@@ -344,6 +356,7 @@ export function recurrenceToJSON(recurrence: Recurrence): string {
         stopType: recurrence.stopType,
         stopDate: recurrence.stopDate,
         stopNumber: recurrence.stopNumber,
+        resetAlarmWhenNotDone: recurrence.resetAlarmWhenNotDone,
     })
 }
 
@@ -368,5 +381,6 @@ export function recurrenceFromJSON(JSONstring: string): Recurrence {
     recurrence.stopType = String(parsedJSON.stopType)
     recurrence.stopDate = String(parsedJSON.stopDate)
     recurrence.stopNumber = Number(parsedJSON.stopNumber)
+    recurrence.resetAlarmWhenNotDone = Boolean(parsedJSON.resetAlarmWhenNotDone)
     return recurrence
 }

--- a/test/mocks/api.ts
+++ b/test/mocks/api.ts
@@ -22,6 +22,7 @@ const joplin: any = {
 	settings: {
 		// Returns false by default so e.g. the @Trace() "debug enabled" check is off.
 		value: jest.fn(async () => false),
+		setValue: jest.fn(async () => undefined),
 		onChange: jest.fn(),
 		registerSection: jest.fn(),
 		registerSettings: jest.fn(),
@@ -83,6 +84,8 @@ export function resetJoplinMock(): void {
 
 	joplin.settings.value.mockReset();
 	joplin.settings.value.mockImplementation(async () => false);
+	joplin.settings.setValue.mockReset();
+	joplin.settings.setValue.mockImplementation(async () => undefined);
 	joplin.settings.onChange.mockReset();
 	joplin.settings.registerSection.mockReset();
 	joplin.settings.registerSettings.mockReset();

--- a/test/recurrence.manager.test.ts
+++ b/test/recurrence.manager.test.ts
@@ -3,6 +3,7 @@
 // The storage layer (RecurrenceStore) and the Joplin wrapper (JoplinAPI) are mocked so the engine
 // logic can be asserted in isolation. The real Recurrence model is used so date math is exercised.
 
+import joplin from 'api';
 import { RecurrenceManager } from '../src/core/recurrence';
 import { RecurrenceStore, RecurringTodo } from '../src/core/database';
 import { JoplinAPI } from '../src/core/joplin';
@@ -56,6 +57,9 @@ beforeEach(() => {
   mockApi.markTaskIncomplete.mockResolvedValue(undefined);
   mockApi.markSubTasksIncomplete.mockResolvedValue(undefined);
   mockApi.markTaskComplete.mockResolvedValue(undefined);
+  mockStore.removeAll.mockResolvedValue(0);
+  // showMessageBox returns 0 (OK) unless a test says otherwise.
+  (joplin.views.dialogs.showMessageBox as jest.Mock).mockResolvedValue(0);
   // Reset the static re-entrancy guard between tests.
   (RecurrenceManager as any).updating = false;
 });
@@ -357,5 +361,39 @@ describe('RecurrenceManager stop-by-number', () => {
     expect(recurrence.stopNumber).toBe(2);
     expect(mockStore.set).toHaveBeenCalledWith('note-1', recurrence);
     expect(mockStore.remove).not.toHaveBeenCalled();
+  });
+});
+
+describe('RecurrenceManager.clearAllRecurrences', () => {
+  it('clears every recurrence once the user confirms', async () => {
+    mockStore.removeAll.mockResolvedValue(4);
+
+    const cleared = await RecurrenceManager.clearAllRecurrences();
+
+    expect(cleared).toBe(4);
+    expect(mockStore.removeAll).toHaveBeenCalledTimes(1);
+    // The to-dos themselves are untouched: no due dates moved, no completion state changed.
+    expect(mockApi.setTaskDueDate).not.toHaveBeenCalled();
+    expect(mockApi.markTaskComplete).not.toHaveBeenCalled();
+    expect(mockApi.markTaskIncomplete).not.toHaveBeenCalled();
+    expect(mockApi.markSubTasksIncomplete).not.toHaveBeenCalled();
+  });
+
+  it('clears nothing when the user cancels the confirmation', async () => {
+    // showMessageBox returns 1 for Cancel.
+    (joplin.views.dialogs.showMessageBox as jest.Mock).mockResolvedValue(1);
+
+    const cleared = await RecurrenceManager.clearAllRecurrences();
+
+    expect(cleared).toBe(-1);
+    expect(mockStore.removeAll).not.toHaveBeenCalled();
+  });
+
+  it('reports back when there was nothing to clear', async () => {
+    mockStore.removeAll.mockResolvedValue(0);
+
+    expect(await RecurrenceManager.clearAllRecurrences()).toBe(0);
+    // Confirmation + result message.
+    expect(joplin.views.dialogs.showMessageBox).toHaveBeenCalledTimes(2);
   });
 });

--- a/test/recurrence.manager.test.ts
+++ b/test/recurrence.manager.test.ts
@@ -3,7 +3,6 @@
 // The storage layer (RecurrenceStore) and the Joplin wrapper (JoplinAPI) are mocked so the engine
 // logic can be asserted in isolation. The real Recurrence model is used so date math is exercised.
 
-import joplin from 'api';
 import { RecurrenceManager } from '../src/core/recurrence';
 import { RecurrenceStore, RecurringTodo } from '../src/core/database';
 import { JoplinAPI } from '../src/core/joplin';
@@ -14,16 +13,6 @@ jest.mock('../src/core/joplin');
 
 const mockStore = RecurrenceStore as jest.Mocked<typeof RecurrenceStore>;
 const mockApi = JoplinAPI as jest.Mocked<typeof JoplinAPI>;
-
-/**
- * Sets the `resetAlarmWhenNotDone` setting for a test while leaving every other setting (notably
- * `debug`, which drives @Trace) off.
- */
-function setResetAlarmWhenNotDone(enabled: boolean): void {
-  (joplin.settings.value as jest.Mock).mockImplementation(
-    async (key: string) => (key === 'resetAlarmWhenNotDone' ? enabled : false)
-  );
-}
 
 /** Milliseconds offset from now, for time-relative test fixtures. */
 function fromNow(ms: number): number {
@@ -67,8 +56,6 @@ beforeEach(() => {
   mockApi.markTaskIncomplete.mockResolvedValue(undefined);
   mockApi.markSubTasksIncomplete.mockResolvedValue(undefined);
   mockApi.markTaskComplete.mockResolvedValue(undefined);
-  // Default to the old behaviour; the alarm-reset tests opt in explicitly.
-  setResetAlarmWhenNotDone(false);
   // Reset the static re-entrancy guard between tests.
   (RecurrenceManager as any).updating = false;
 });
@@ -92,7 +79,7 @@ describe('RecurrenceManager.updateAllRecurrences (sweep)', () => {
     expect(mockStore.remove).not.toHaveBeenCalled();
   });
 
-  it('does not advance an incomplete todo when alarm reset is off', async () => {
+  it('does not advance an incomplete todo when alarm reset is off for it', async () => {
     const todo = makeTodo({ todo_completed: 0 });
     mockStore.getAllRecurringTodos.mockResolvedValue([todo]);
 
@@ -194,7 +181,7 @@ describe('RecurrenceManager.handleAlarm', () => {
     expect(mockApi.setTaskDueDate).toHaveBeenCalledTimes(1);
   });
 
-  it('no-ops on an incomplete todo when alarm reset is off', async () => {
+  it('no-ops on an incomplete todo when alarm reset is off for it', async () => {
     mockApi.getNote.mockResolvedValue({
       id: 'note-1',
       is_todo: 1,
@@ -209,7 +196,7 @@ describe('RecurrenceManager.handleAlarm', () => {
   });
 });
 
-describe('RecurrenceManager alarm reset (resetAlarmWhenNotDone)', () => {
+describe('RecurrenceManager alarm reset (per-to-do resetAlarmWhenNotDone)', () => {
   /** An incomplete todo whose alarm went off an hour ago. */
   function overdueOpenNote(overrides: Record<string, any> = {}) {
     return {
@@ -223,10 +210,9 @@ describe('RecurrenceManager alarm reset (resetAlarmWhenNotDone)', () => {
   }
 
   it('re-arms the alarm on the next occurrence without completing the todo', async () => {
-    setResetAlarmWhenNotDone(true);
     const note = overdueOpenNote();
     mockApi.getNote.mockResolvedValue(note);
-    const recurrence = dailyRecurrence();
+    const recurrence = dailyRecurrence({ resetAlarmWhenNotDone: true });
     mockStore.get.mockResolvedValue(recurrence);
 
     await RecurrenceManager.handleAlarm('note-1');
@@ -245,11 +231,12 @@ describe('RecurrenceManager alarm reset (resetAlarmWhenNotDone)', () => {
   });
 
   it('skips past every missed occurrence so the new alarm is in the future', async () => {
-    setResetAlarmWhenNotDone(true);
     // Hourly recurrence that was last due three and a half hours ago.
     const dueAt = fromNow(-3.5 * ONE_HOUR);
     mockApi.getNote.mockResolvedValue(overdueOpenNote({ todo_due: dueAt }));
-    mockStore.get.mockResolvedValue(dailyRecurrence({ interval: 'hour' }));
+    mockStore.get.mockResolvedValue(
+      dailyRecurrence({ interval: 'hour', resetAlarmWhenNotDone: true })
+    );
 
     await RecurrenceManager.handleAlarm('note-1');
 
@@ -260,9 +247,8 @@ describe('RecurrenceManager alarm reset (resetAlarmWhenNotDone)', () => {
   });
 
   it('leaves a todo alone when its alarm has not fired yet', async () => {
-    setResetAlarmWhenNotDone(true);
     mockApi.getNote.mockResolvedValue(overdueOpenNote({ todo_due: fromNow(ONE_HOUR) }));
-    mockStore.get.mockResolvedValue(dailyRecurrence());
+    mockStore.get.mockResolvedValue(dailyRecurrence({ resetAlarmWhenNotDone: true }));
 
     await RecurrenceManager.handleAlarm('note-1');
 
@@ -271,9 +257,8 @@ describe('RecurrenceManager alarm reset (resetAlarmWhenNotDone)', () => {
   });
 
   it('leaves a todo with no due date alone', async () => {
-    setResetAlarmWhenNotDone(true);
     mockApi.getNote.mockResolvedValue(overdueOpenNote({ todo_due: 0 }));
-    mockStore.get.mockResolvedValue(dailyRecurrence());
+    mockStore.get.mockResolvedValue(dailyRecurrence({ resetAlarmWhenNotDone: true }));
 
     await RecurrenceManager.handleAlarm('note-1');
 
@@ -281,8 +266,11 @@ describe('RecurrenceManager alarm reset (resetAlarmWhenNotDone)', () => {
   });
 
   it('catches alarms missed while Joplin was closed via the safety-net sweep', async () => {
-    setResetAlarmWhenNotDone(true);
-    const todo = makeTodo({ todo_due: fromNow(-ONE_HOUR), todo_completed: 0 });
+    const todo = makeTodo({
+      todo_due: fromNow(-ONE_HOUR),
+      todo_completed: 0,
+      recurrence: dailyRecurrence({ resetAlarmWhenNotDone: true }),
+    });
     mockStore.getAllRecurringTodos.mockResolvedValue([todo]);
 
     await RecurrenceManager.updateAllRecurrences();
@@ -292,8 +280,11 @@ describe('RecurrenceManager alarm reset (resetAlarmWhenNotDone)', () => {
   });
 
   it('consumes an occurrence of a stop-after-N recurrence when the alarm is skipped', async () => {
-    setResetAlarmWhenNotDone(true);
-    const recurrence = dailyRecurrence({ stopType: 'number', stopNumber: 1 });
+    const recurrence = dailyRecurrence({
+      stopType: 'number',
+      stopNumber: 1,
+      resetAlarmWhenNotDone: true,
+    });
     mockApi.getNote.mockResolvedValue(overdueOpenNote());
     mockStore.get.mockResolvedValue(recurrence);
 
@@ -304,17 +295,37 @@ describe('RecurrenceManager alarm reset (resetAlarmWhenNotDone)', () => {
     expect(mockStore.remove).toHaveBeenCalledWith('note-1');
   });
 
-  it('defaults to on when the setting cannot be read', async () => {
-    (joplin.settings.value as jest.Mock).mockImplementation(async (key: string) => {
-      if (key === 'resetAlarmWhenNotDone') throw new Error('setting not registered');
-      return false;
-    });
+  it('is off by default, so an overdue open to-do is left alone', async () => {
     mockApi.getNote.mockResolvedValue(overdueOpenNote());
     mockStore.get.mockResolvedValue(dailyRecurrence());
 
     await RecurrenceManager.handleAlarm('note-1');
 
+    expect(mockApi.setTaskDueDate).not.toHaveBeenCalled();
+    expect(mockStore.set).not.toHaveBeenCalled();
+  });
+
+  it('only touches the to-dos that opted in, not every recurring to-do', async () => {
+    const optedIn = makeTodo({
+      id: 'note-opted-in',
+      todo_due: fromNow(-ONE_HOUR),
+      todo_completed: 0,
+      recurrence: dailyRecurrence({ resetAlarmWhenNotDone: true }),
+    });
+    const untouched = makeTodo({
+      id: 'note-plain',
+      todo_due: fromNow(-ONE_HOUR),
+      todo_completed: 0,
+      recurrence: dailyRecurrence(),
+    });
+    mockStore.getAllRecurringTodos.mockResolvedValue([optedIn, untouched]);
+
+    await RecurrenceManager.updateAllRecurrences();
+
     expect(mockApi.setTaskDueDate).toHaveBeenCalledTimes(1);
+    expect(mockApi.setTaskDueDate.mock.calls[0][0]).toBe('note-opted-in');
+    expect(mockStore.set).toHaveBeenCalledTimes(1);
+    expect(mockStore.set.mock.calls[0][0]).toBe('note-opted-in');
   });
 });
 

--- a/test/recurrence.model.test.ts
+++ b/test/recurrence.model.test.ts
@@ -266,6 +266,7 @@ describe('Object round-trip (recurrenceToObject / recurrenceFromObject)', () => 
 			stopType: 'date',
 			stopDate: '2027-06-15',
 			stopNumber: 9,
+			resetAlarmWhenNotDone: true,
 		});
 		const round = recurrenceFromObject(recurrenceToObject(r));
 		expect(recurrenceToObject(round)).toEqual(recurrenceToObject(r));
@@ -288,6 +289,7 @@ describe('Object round-trip (recurrenceToObject / recurrenceFromObject)', () => 
 		expect(r.stopType).toBe('never');
 		expect(r.stopDate).toBeNull();
 		expect(r.stopNumber).toBe(1);
+		expect(r.resetAlarmWhenNotDone).toBe(false);
 	});
 
 	it('recurrenceFromObject is undefined-safe', () => {
@@ -303,6 +305,13 @@ describe('Object round-trip (recurrenceToObject / recurrenceFromObject)', () => 
 		// Unspecified fields fall back to class defaults.
 		expect(r.intervalNumber).toBe(1);
 		expect(r.stopType).toBe('never');
+	});
+
+	it('leaves the alarm reset off for recurrences stored before the option existed', () => {
+		// Recurrences written by an older version carry no resetAlarmWhenNotDone key, so they must
+		// keep the default: an open to-do stays overdue until it is ticked off.
+		const r = recurrenceFromObject({ enabled: true, interval: 'day', intervalNumber: 1 });
+		expect(r.resetAlarmWhenNotDone).toBe(false);
 	});
 });
 
@@ -343,6 +352,7 @@ describe('JSON round-trip (recurrenceToJSON / recurrenceFromJSON)', () => {
 		expect(round.stopType).toBe(r.stopType);
 		expect(round.stopDate).toBe(r.stopDate);
 		expect(round.stopNumber).toBe(r.stopNumber);
+		expect(round.resetAlarmWhenNotDone).toBe(r.resetAlarmWhenNotDone);
 	});
 
 	it('JSON shape contains exactly the persisted field set', () => {
@@ -355,6 +365,7 @@ describe('JSON round-trip (recurrenceToJSON / recurrenceFromJSON)', () => {
 				'intervalNumber',
 				'monthOrdinal',
 				'monthWeekday',
+				'resetAlarmWhenNotDone',
 				'stopDate',
 				'stopNumber',
 				'stopType',

--- a/test/recurrence.store.test.ts
+++ b/test/recurrence.store.test.ts
@@ -247,4 +247,51 @@ describe("RecurrenceStore", () => {
       expect(results).toEqual([]);
     });
   });
+
+  describe("removeAll", () => {
+    it("clears the recurrence data off every indexed note, to-do or not", async () => {
+      mockDataGet({
+        tags: { items: [{ id: "tag-1", title: "recurring" }], has_more: false },
+        tagNotes: {
+          items: [{ id: "todo-1" }, { id: "todo-2" }, { id: "not-todo" }],
+          has_more: false,
+        },
+      });
+
+      const cleared = await RecurrenceStore.removeAll();
+
+      expect(cleared).toBe(3);
+      for (const id of ["todo-1", "todo-2", "not-todo"]) {
+        expect(joplin.data.userDataDelete).toHaveBeenCalledWith(ModelType.Note, id, "recurrence");
+        expect(joplin.data.delete).toHaveBeenCalledWith(["tags", "tag-1", "notes", id]);
+      }
+      // The notes themselves are never written to — alarms and contents are left alone.
+      expect(joplin.data.put).not.toHaveBeenCalled();
+    });
+
+    it("walks every page of the index", async () => {
+      (joplin.data.get as jest.Mock).mockImplementation(async (path: string[], query: any) => {
+        if (path[0] === "tags" && path.length === 1) {
+          return { items: [{ id: "tag-1", title: "recurring" }], has_more: false };
+        }
+        if (path[0] === "tags" && path[2] === "notes") {
+          return query.page === 1
+            ? { items: [{ id: "todo-1" }], has_more: true }
+            : { items: [{ id: "todo-2" }], has_more: false };
+        }
+        return { items: [], has_more: false };
+      });
+
+      expect(await RecurrenceStore.removeAll()).toBe(2);
+      expect(joplin.data.userDataDelete).toHaveBeenCalledWith(ModelType.Note, "todo-2", "recurrence");
+    });
+
+    it("clears nothing when no recurring tag exists and none can be created", async () => {
+      mockDataGet({ tags: { items: [], has_more: false } });
+      (joplin.data.post as jest.Mock).mockResolvedValue(null);
+
+      expect(await RecurrenceStore.removeAll()).toBe(0);
+      expect(joplin.data.userDataDelete).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -1,0 +1,108 @@
+// Unit tests for SettingsManager, in particular the one-shot "remove all recurrence settings"
+// toggle: it must run the clear exactly when it is switched on, and switch itself back off after.
+
+import joplin from 'api';
+import { SettingsManager } from '../src/core/settings';
+import { RecurrenceManager } from '../src/core/recurrence';
+import { RecurrenceScheduler } from '../src/core/timer';
+
+jest.mock('../src/core/recurrence');
+jest.mock('../src/core/timer');
+
+const mockManager = RecurrenceManager as jest.Mocked<typeof RecurrenceManager>;
+const mockScheduler = RecurrenceScheduler as jest.Mocked<typeof RecurrenceScheduler>;
+
+const CLEAR_ALL_KEY = 'clearAllRecurrences';
+
+/** Registers the settings and returns the onChange handler Joplin was given. */
+async function setupAndGetChangeHandler(): Promise<(event: any) => Promise<void>> {
+  await SettingsManager.setup();
+  const handler = (joplin.settings.onChange as jest.Mock).mock.calls[0][0];
+  // The registration sweep is irrelevant to the assertions below.
+  jest.clearAllMocks();
+  return handler;
+}
+
+/** Makes joplin.settings.value report `value` for the clear-all toggle, false for everything else. */
+function setToggle(value: boolean): void {
+  (joplin.settings.value as jest.Mock).mockImplementation(async (key: string) =>
+    key === CLEAR_ALL_KEY ? value : false
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setToggle(false);
+  mockManager.clearAllRecurrences.mockResolvedValue(0);
+  mockScheduler.start.mockResolvedValue(undefined);
+  (joplin.settings.setValue as jest.Mock).mockResolvedValue(undefined);
+  (SettingsManager as any).clearing = false;
+});
+
+describe('SettingsManager.setup', () => {
+  it('registers the clear-all toggle, off by default', async () => {
+    await SettingsManager.setup();
+
+    const registered = (joplin.settings.registerSettings as jest.Mock).mock.calls[0][0];
+    expect(registered[CLEAR_ALL_KEY]).toBeDefined();
+    expect(registered[CLEAR_ALL_KEY].value).toBe(false);
+    expect(registered[CLEAR_ALL_KEY].public).toBe(true);
+  });
+});
+
+describe('SettingsManager clear-all toggle', () => {
+  it('clears every recurrence when the toggle is switched on, then switches it back off', async () => {
+    const onChange = await setupAndGetChangeHandler();
+    setToggle(true);
+    mockManager.clearAllRecurrences.mockResolvedValue(3);
+
+    await onChange({ keys: [CLEAR_ALL_KEY] });
+
+    expect(mockManager.clearAllRecurrences).toHaveBeenCalledTimes(1);
+    expect(joplin.settings.setValue).toHaveBeenCalledWith(CLEAR_ALL_KEY, false);
+  });
+
+  it('does nothing when a different setting changes', async () => {
+    const onChange = await setupAndGetChangeHandler();
+    setToggle(true);
+
+    await onChange({ keys: ['updateFrequency'] });
+
+    expect(mockManager.clearAllRecurrences).not.toHaveBeenCalled();
+    expect(joplin.settings.setValue).not.toHaveBeenCalled();
+    // The scheduler still restarts, as it does for any setting change.
+    expect(mockScheduler.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when the toggle change is the reset back to off', async () => {
+    const onChange = await setupAndGetChangeHandler();
+    setToggle(false);
+
+    await onChange({ keys: [CLEAR_ALL_KEY] });
+
+    expect(mockManager.clearAllRecurrences).not.toHaveBeenCalled();
+    expect(joplin.settings.setValue).not.toHaveBeenCalled();
+  });
+
+  it('still switches the toggle off when the clear fails', async () => {
+    const onChange = await setupAndGetChangeHandler();
+    setToggle(true);
+    mockManager.clearAllRecurrences.mockRejectedValue(new Error('boom'));
+
+    await onChange({ keys: [CLEAR_ALL_KEY] });
+
+    expect(joplin.settings.setValue).toHaveBeenCalledWith(CLEAR_ALL_KEY, false);
+    // A failed clear must not wedge the guard, or the toggle would never work again.
+    expect((SettingsManager as any).clearing).toBe(false);
+  });
+
+  it('does not re-enter while a clear is already running', async () => {
+    const onChange = await setupAndGetChangeHandler();
+    setToggle(true);
+    (SettingsManager as any).clearing = true;
+
+    await onChange({ keys: [CLEAR_ALL_KEY] });
+
+    expect(mockManager.clearAllRecurrences).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The alarm-reset behaviour shipped as a plugin-wide setting that defaulted
to on, so it applied to every repeating to-do at once: the first
safety-net sweep after the change re-armed the alarm on every open
recurring to-do whose occurrence had passed, whether or not the user
wanted that to-do to move on by itself. Nothing was opted in, and there
was no way to keep one to-do overdue while letting another roll forward.

The choice now lives on the recurrence itself, as "Move the alarm on even
when this To-Do is not done" in the recurrence dialog, and it defaults to
off. Only a to-do the user ticked it on advances on a passed alarm; every
other repeating to-do stays overdue until it is ticked off, as before.

Because recurrences stored by earlier versions carry no such key,
recurrenceFromObject leaves them on the default - so existing to-dos keep
the plain behaviour without any migration.

The global resetAlarmWhenNotDone setting is removed; the per-to-do flag is
the only source of truth.

Tests: the manager suite opts individual recurrences in rather than
stubbing a setting, and gains a case asserting a sweep touches only the
opted-in to-do. The model suite pins the new field into both round-trip
contracts and asserts a pre-existing recurrence deserializes with the
reset off. E2E covers the dialog round-trip, the opted-in reset, and an
overdue to-do that did not opt in keeping its alarm.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lr1ciSv4vCCRMumwFeeyj4